### PR TITLE
Fix issue with date formats with week day names with accent letters.

### DIFF
--- a/NTemplates/FunctionsEvaluator.cs
+++ b/NTemplates/FunctionsEvaluator.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Text;
 using System.Text.RegularExpressions;
 using NTemplates.DocumentStructure;
 
@@ -29,7 +30,7 @@ namespace NTemplates
                     {
                         case TemplateFunctions.DateFormat:
                             {
-                                return DateTime.Parse(GetStringData(data, manager, m, function)).ToString(format);
+                                return DataManager.GetRtfText(DateTime.Parse(GetStringData(data, manager, m, function)).ToString(format), Encoding.UTF32);
                             }
                         case TemplateFunctions.DoubleFormat:
                             {


### PR DESCRIPTION
In Italian week day names have accents (e.g.: lunedì, martedì, mercoledì, giovedì e venerdì).
This fixes the RTF rendering.